### PR TITLE
Use the Upload Directory for Log Files

### DIFF
--- a/global.php
+++ b/global.php
@@ -56,7 +56,11 @@ define('CRAYON_THEME_EDITOR_PATH', CRAYON_ROOT_PATH . CRAYON_UTIL_DIR . CRAYON_T
 
 // Files
 
-define('CRAYON_LOG_FILE', CRAYON_ROOT_PATH . 'log.txt');
+if(($udir = wp_upload_dir()) && isset($udir['path'])) {
+    define('CRAYON_LOG_FILE', trailingslashit($udir['path']) . 'crayon-log.txt');
+} else {
+    define('CRAYON_LOG_FILE', CRAYON_ROOT_PATH . 'log.txt');
+}
 define('CRAYON_TOUCH_FILE', CRAYON_UTIL_PATH . 'touch.txt');
 define('CRAYON_LOG_MAX_SIZE', 50000); // Bytes
 


### PR DESCRIPTION
Instead of saving the log file in the plugin directory (where it likely gets obliterated by plugin updates?), save it in the user's upload directory.

This commit does that, but it brings up a few other issues.  The one I encountered was the sample code breaking on the admin page.  I get a notice that `wp_upload_dir`, the fuction I used to grab the upload directory, doesn't exist.  Which is should: it's in `wp-includes/functions.php` which gets loaded way early.  I suspect the issue is coming from doing ajax requests the wrong way (eg. using a custom PHP file and including `wp-load.php`).  WordPress has a nice [API for AJAX](http://codex.wordpress.org/AJAX_in_Plugins) that you should consider converting to.

The other option would be moving `CRAYON_LOG_FILE` into the main plugin file.
