### PR TITLE
Forcing ltr

### DIFF
--- a/css/crayon_style.css
+++ b/css/crayon_style.css
@@ -15,6 +15,8 @@ coloring etc.
 .crayon-syntax {
     overflow: hidden !important;
     position: relative !important;
+    direction: ltr;
+    text-align: left;
 }
 
 .crayon-syntax div {


### PR DESCRIPTION
Added ltr direction and left align to the "crayon-syntax" css class, so that rtl languages (such as Arabic) won't spoil the direction of the code snippet.
