### PR TITLE
\ should be allowed as part of valid key strings

### DIFF
--- a/langs/yaml/yaml.txt
+++ b/langs/yaml/yaml.txt
@@ -4,15 +4,15 @@
 
     NAME                YAML
     VERSION             1.8.1
-    ALLOW_MIXED			NO
+    ALLOW_MIXED         NO
 
     COMMENT             #.*?$
     QUOTED:IDENTIFIER   ("[^"]*")|('[^']*')
-    VALUES:IDENTIFIER	\[[^\]]*\]
-    
-	LIST_KEY:STRING     ((\-\s*)?[\w-]+(?=\s*:))|(\-\s*(?=\{))
-	TAG     			%(\w+)
-    ANCHOR:CONSTANT		&\w+
-    REF:ENTITY			\*\w+
+    VALUES:IDENTIFIER   \[[^\]]*\]
+
+    LIST_KEY:STRING     ((\-\s*)?[\w-\\]+(?=\s*:))|(\-\s*(?=\{))
+    TAG                 %(\w+)
+    ANCHOR:CONSTANT     &\w+
+    REF:ENTITY          \*\w+
     OPERATOR            (?alt:operator.txt)
     SYMBOL              (?default)


### PR DESCRIPTION
Example of key with backslash can be found here : https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/index.md#step-4-configure-your-applications-securityyml

Also fixed the indentation (was mainly 4 spaces but included some tabs, now only 4 spaces).
