### PR TITLE
Fixed Applescript string regex

### DIFF
--- a/langs/applescript/applescript.txt
+++ b/langs/applescript/applescript.txt
@@ -6,7 +6,7 @@
     VERSION             1.9.13
 
     COMMENT             ((--|#).*?$)|(\(\*.*?\*\))
-    STRING              (?default)
+    STRING              (".*?")
     
     STATEMENT           \b(?alt:statement.txt)\b
     RESERVED            \b(?alt:reserved.txt)\b


### PR DESCRIPTION
I updated the regex for Applescript strings, overriding the default settings. This will fix [issue 84](https://github.com/aramkocharyan/crayon-syntax-highlighter/issues/84)
