### PR TITLE
Prevent Safari from enlarging font on mobile

### DIFF
--- a/css/src/crayon_style.css
+++ b/css/src/crayon_style.css
@@ -21,6 +21,7 @@ coloring etc.
     direction: ltr !important;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
+    -webkit-text-size-adjust: none;
 }
 
 .crayon-syntax div {


### PR DESCRIPTION
This will cause line not to align with line numbers.
