### PR TITLE
Prevent wrapping line numbers in some themes

### DIFF
--- a/themes/github/github.css
+++ b/themes/github/github.css
@@ -31,6 +31,7 @@ URL: http://firn.jp/
 .crayon-theme-github .crayon-table .crayon-nums-content {
   padding-top: 5px !important;
   padding-bottom: 3px !important;
+  white-space: nowrap; /* Prevent wrapping line numbers in some themes */
 }
 
 .crayon-theme-github .crayon-table .crayon-num {


### PR DESCRIPTION
I am using a custom wordpress theme and Crayon just can not display line numbers correctly without this line.
