### PR TITLE
Escape single quotes from code blocks

### DIFF
--- a/util/crayon_util.class.php
+++ b/util/crayon_util.class.php
@@ -412,7 +412,7 @@ EOT;
     }
 
     public static function html_entity_decode($str) {
-        return html_entity_decode($str, ENT_COMPAT, 'UTF-8');
+        return html_entity_decode($str, ENT_QUOTES, 'UTF-8');
     }
 
     // Converts <, >, & into entities


### PR DESCRIPTION
The current behavior of Crayon is to escape every special character but keep &#39; instead of single quotes. According to the PHP documentation, ENT_QUOTES will convert both double and single quotes. Changing the flags to ENT_QUOTES in html_entity_decode fixed it for me without breaking anything.
