### PR TITLE
C# - Added Dynamic Type and var implicit type

### DIFF
--- a/langs/c#/type.txt
+++ b/langs/c#/type.txt
@@ -24,3 +24,5 @@ void
 long
 enum
 int
+dynamic
+var


### PR DESCRIPTION
`var` and `dynamic` are used in variable definitions in C#. Added them for Crayon support
