### PR TITLE
C# - Added get and set keywords

### DIFF
--- a/langs/c#/statement.txt
+++ b/langs/c#/statement.txt
@@ -21,3 +21,5 @@ if
 in
 do
 is
+get
+set


### PR DESCRIPTION
In C#, you can write something like:

```
public class SomeClass
{
    int _somevalue;
    public int SomeProperty
    {
        get
        {
            return _someValue;
        }
        set
        {
            _someValue = value;
        }
    }
}
```

This adds support for `get` and `set` in this example.

Improves the problem explained in #149 as well.
