### PR TITLE
Powershell add 'here-strings'; ignore escaped strings and comments

### DIFF
--- a/langs/c#/c#.txt
+++ b/langs/c#/c#.txt
@@ -5,10 +5,9 @@
     NAME                C#
     VERSION             1.8.1
 
-    #                   single-line    | multi-line
-    COMMENT             ((?<!`)(#.*?$))|((?<!`)(<#*.*?(?<!`)#>))
-    #                   default   | unescaped here-string
-    STRING              (?default)|((?<!`)(@\".*?^\s*(?<!`)\"@))
+    COMMENT             (?default)
+    PREPROCESSOR		(?default)
+    STRING              (?default)
     
     STATEMENT           \b(?alt:statement.txt)\b
     RESERVED            \b(?alt:reserved.txt)\b


### PR DESCRIPTION
This adds support for 'here-strings' (as described in Issue #177).  Powershell uses the backtick (`), aka grave-accent, as its escape character.  This checks for it before what might otherwise be seen as a comment or string.
