### PR TITLE
PowerShell: Add single-quoted here-strings

### DIFF
--- a/langs/ps/ps.txt
+++ b/langs/ps/ps.txt
@@ -6,7 +6,8 @@
     VERSION             1.8.2
 
     COMMENT             ((?<!`)#.*?$)|((?<!`)<#.*?(?<!`)#>)
-    STRING              ((?<!`)".*?(?<!`)")|((?<!`)'.*?(?<!`)')|((?<!`)(@\".*?^\s*(?<!`)\"@))
+    HERESTRING:STRING   ((?<!`)(@\".*?^\s*(?<!`)\"@))|((?<!`)(@\'.*?^\s*(?<!`)\'@))
+    STRING              ((?<!`)".*?(?<!`)")|((?<!`)'.*?(?<!`)')
         
     FUNCTIONS:RESERVED  (\b(?alt:reserved.txt)\b)|((?-i)[A-Z]\w+-[A-Z]\w+(?i))
     STATEMENT           \b(?alt:statement.txt)\b


### PR DESCRIPTION
This adds support for single-quoted here-strings (more of Issue #177):

$this = @'
  this is also a here string!
'@

I've created a new element (HERESTRING) to simplify the code a bit.
