### PR TITLE
C#: Add verbatim strings (like PowerShell's Here-String)

### DIFF
--- a/langs/c#/c#.txt
+++ b/langs/c#/c#.txt
@@ -7,6 +7,7 @@
 
     COMMENT             (?default)
     PREPROCESSOR		(?default)
+    VERBATIMSTR:STRING  (?<!\\)(@\".*?(?<!(\"))\")
     STRING              (?default)
     
     STATEMENT           \b(?alt:statement.txt)\b


### PR DESCRIPTION
C# has multi-line "verbatim strings" of the form:

$var =  @"string content
and more content"

There's no single-quote version and regular escape chars () aren't recognized in the string --- only double double-quotes (""), which become a single double-quote.  This also checks that the '@' isn't escaped with a .
