### PR TITLE
Powershell: disable backticks in HereStrings and Single-Quoted strings

### DIFF
--- a/langs/ps/ps.txt
+++ b/langs/ps/ps.txt
@@ -6,8 +6,8 @@
     VERSION             1.8.2
 
     COMMENT             ((?<!`)#.*?$)|((?<!`)<#.*?(?<!`)#>)
-    HERESTRING:STRING   ((?<!`)(@\".*?^\s*(?<!`)\"@))|((?<!`)(@\'.*?^\s*(?<!`)\'@))
-    STRING              ((?<!`)".*?(?<!`)")|((?<!`)'.*?(?<!`)')
+    HERESTRING:STRING   ((?<!`)(@\".*?^\s*\"@))|((?<!`)(@\'.*?^\s*\'@))
+    STRING              ((?<!`)".*?(?<!`)")|((?<!`)'.*?')
         
     FUNCTIONS:RESERVED  (\b(?alt:reserved.txt)\b)|((?-i)[A-Z]\w+-[A-Z]\w+(?i))
     STATEMENT           \b(?alt:statement.txt)\b


### PR DESCRIPTION
This disables backtick-escaping within all here-strings (single- and double-quoted) as well as in regular single-quoted strings as described by @ITFiend in his [comment](https://github.com/aramk/crayon-syntax-highlighter/issues/177#issuecomment-42261258) in #177.  Backtick-escaping will still work in double-quoted strings.
