### PR TITLE
default string change

### DIFF
--- a/langs/default/default.txt
+++ b/langs/default/default.txt
@@ -7,7 +7,7 @@
 
     COMMENT             (/\*.*?\*/)|(//.*?$)
     PREPROCESSOR		(#.*?$)
-    STRING              ((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')
+    STRING              ((?<![^\\]\\)".*?(?<![^\\]\\)")|((?<![^\\]\\)'.*?(?<![^\\]\\)')
     
     STATEMENT           \b(?alt:statement.txt)\b
     RESERVED            \b(?<![:\.])(?alt:reserved.txt)\b


### PR DESCRIPTION
This fixes the case where someone wants to write the backslash character at the end of a string, i.e.
char backslash = '\';

As it currently stands, that would see the \' at the end of the string, think it's an escaped end quote, and not end the string.
