### PR TITLE
Update objc.txt

### DIFF
--- a/langs/objc/objc.txt
+++ b/langs/objc/objc.txt
@@ -8,7 +8,7 @@
     COMMENT             (?default)
     PREPROCESSOR		(?default)
     STRING              (@?(?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')
-    NOTATION            \<.+\>
+    NOTATION            \<\ ?[a-zA-Z]+\ ?\>
     
     STATEMENT           (?alt:statement_at.txt)\b|\b(?alt:statement.txt)\b
     RESERVED            (?alt:reserved_at.txt)\b|\b(?alt:reserved.txt)\b


### PR DESCRIPTION
Before, this would aggressively match anything appearing between < and >.  This is awkward if you have code that has less-than and greater-than comparisons in it.  Even if they appear on different lines, everything between is caught up as "notation".
