### PR TITLE
Add an option to load crayon_js at footer.

### DIFF
--- a/crayon_settings.class.php
+++ b/crayon_settings.class.php
@@ -117,6 +117,7 @@ class CrayonSettings {
     const EXPAND_TOGGLE = 'expand-toggle';
     const MINIMIZE = 'minimize';
     const IGNORE = 'ignore';
+    const DELAY_LOAD_JS = 'delay-load-js';
 
     private static $cache_array;
 
@@ -254,7 +255,8 @@ class CrayonSettings {
             new CrayonSetting(self::WRAP, FALSE),
             new CrayonSetting(self::EXPAND, FALSE),
             new CrayonSetting(self::EXPAND_TOGGLE, TRUE),
-            new CrayonSetting(self::MINIMIZE, FALSE)
+            new CrayonSetting(self::MINIMIZE, FALSE),
+            new CrayonSetting(self::DELAY_LOAD_JS, FALSE)
         );
 
         $this->set($settings);

--- a/crayon_settings_wp.class.php
+++ b/crayon_settings_wp.class.php
@@ -1149,6 +1149,8 @@ class Human {
         self::checkbox(array(CrayonSettings::DISABLE_RUNTIME, crayon__('Disable runtime stats')));
         echo '<span class="crayon-span-100">' . crayon__('Disable for posts before') . ':</span> ';
         self::input(array('id' => CrayonSettings::DISABLE_DATE, 'type' => 'date', 'size' => 8, 'break' => FALSE));
+        echo '<br/>';
+        self::checkbox(array(CrayonSettings::DELAY_LOAD_JS, crayon__('Load Crayon JS at page footer for better page loading performance. Require wp_footer() being called in theme.')));
     }
 
     // Debug Fields ===========================================================

--- a/crayon_wp.class.php
+++ b/crayon_wp.class.php
@@ -542,9 +542,10 @@ class CrayonWP {
 
             CrayonLog::debug('enqueue');
             global $CRAYON_VERSION;
+            CrayonSettingsWP::load_settings(TRUE);
             if (CRAYON_MINIFY) {
                 wp_enqueue_style('crayon', plugins_url(CRAYON_STYLE_MIN, __FILE__), array(), $CRAYON_VERSION);
-                wp_enqueue_script('crayon_js', plugins_url(CRAYON_JS_MIN, __FILE__), array('jquery'), $CRAYON_VERSION);
+                wp_enqueue_script('crayon_js', plugins_url(CRAYON_JS_MIN, __FILE__), array('jquery'), $CRAYON_VERSION, CrayonGlobalSettings::val(CrayonSettings::DELAY_LOAD_JS));
             } else {
                 wp_enqueue_style('crayon_style', plugins_url(CRAYON_STYLE, __FILE__), array(), $CRAYON_VERSION);
                 wp_enqueue_style('crayon_global_style', plugins_url(CRAYON_STYLE_GLOBAL, __FILE__), array(), $CRAYON_VERSION);


### PR DESCRIPTION
Crayon js can be put at the bottom of blog pages for better rendering performance. More information at Google Pagespeed Insights: https://developers.google.com/speed/docs/insights/BlockingJS

Crayon does rendering after document.ready, so it is safe to move to the end of the page.

The diffing seems not correct. Use ?w=1 in the url to ignore whitespaces, if you see whole file gets changed.
