### PR TITLE
Non-static method CrayonFormatter::print_error() should not be called statically

### DIFF
--- a/crayon_formatter.class.php
+++ b/crayon_formatter.class.php
@@ -481,7 +481,7 @@ class CrayonFormatter {
 		}
 	}
 
-	function print_error($hl, $error, $line_numbers = 'ERROR', $print = TRUE) {
+	public static function print_error($hl, $error, $line_numbers = 'ERROR', $print = TRUE) {
 		if (get_class($hl) != CRAYON_HIGHLIGHTER) {
 			return;
 		}


### PR DESCRIPTION
Hello, 
I got the following PHP strict error in the plugin settings page :
```
Strict standards: Non-static method CrayonFormatter::print_error() should not be called statically, assuming $this from incompatible context in /var/www/wp-content/plugins/crayon-syntax-highlighter/crayon_highlighter.class.php on line 214
```
I think you just forget the static keyword in the method declaration ;)