### PR TITLE
Added the new nameof operator for C# 6.0

### DIFF
--- a/langs/c#/reserved.txt
+++ b/langs/c#/reserved.txt
@@ -3,6 +3,7 @@ unchecked
 delegate
 explicit
 checked
+nameof
 params
 typeof
 sizeof


### PR DESCRIPTION
Added the new nameof operator for C# 6.0. See https://github.com/aramk/crayon-syntax-highlighter/issues/272.