### PR TITLE
Remove parsing plugin data hack

### DIFF
--- a/crayon_wp.class.php
+++ b/crayon_wp.class.php
@@ -33,11 +33,12 @@ if (CRAYON_THEME_EDITOR) {
 }
 require_once('crayon_settings_wp.class.php');
 
-if (defined('ABSPATH')) {
-    // Used to get plugin version info
-    require_once(ABSPATH . 'wp-admin/includes/plugin.php');
-    crayon_set_info(get_plugin_data(__FILE__));
-}
+crayon_set_info(array(
+	'Version' => '_2.7.2_beta',
+	'Date' => '25th April, 2015',
+	'AuthorName' => 'Aram Kocharyan',
+	'PluginURI' => 'https://github.com/aramk/crayon-syntax-highlighter',
+));
 
 /* The plugin class that manages all other classes and integrates Crayon with WP */
 

--- a/global.php
+++ b/global.php
@@ -175,7 +175,7 @@ function crayon_set_info($info_array) {
     if (($date = @filemtime(CRAYON_README_FILE)) !== FALSE) {
         $CRAYON_DATE = date("jS F, Y", $date);
     }
-    crayon_set_info_key('AuthorName', $info_array, $CRAYON_A);
+    crayon_set_info_key('AuthorName', $info_array, $CRAYON_AUTHOR);
     crayon_set_info_key('PluginURI', $info_array, $CRAYON_WEBSITE);
 }
 

--- a/global.php
+++ b/global.php
@@ -172,9 +172,7 @@ function crayon_set_info($info_array) {
         return;
     }
     crayon_set_info_key('Version', $info_array, $CRAYON_VERSION);
-    if (($date = @filemtime(CRAYON_README_FILE)) !== FALSE) {
-        $CRAYON_DATE = date("jS F, Y", $date);
-    }
+    crayon_set_info_key('Date', $info_array, $CRAYON_DATE);
     crayon_set_info_key('AuthorName', $info_array, $CRAYON_AUTHOR);
     crayon_set_info_key('PluginURI', $info_array, $CRAYON_WEBSITE);
 }


### PR DESCRIPTION
This fix issue with broken WordPress smart quotes functionality. By default WP convert `"` into typography quotes, so for polish language `Lorem ipsum "dolor sit amet"` become `Lorem ipsum „dolor sit amet”`. Loading `wp-admin/includes/plugin.php` break this - WP converts `"` into english quotes: `Lorem ipsum “dolor sit amet”`, which is incorrect for polish language.

Also, parsing plugin data in this way is a really dirty hack, which could break site when WP team move `get_plugin_data` function into other file - we should really avoid such solutions.