### PR TITLE
fix error log when HTTP_USER_AGENT is missing

### DIFF
--- a/util/crayon_util.class.php
+++ b/util/crayon_util.class.php
@@ -790,7 +790,7 @@ EOT;
 
     // Detect if on a Mac or PC
     public static function is_mac($default = FALSE) {
-        $user = $_SERVER['HTTP_USER_AGENT'];
+        $user = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
         if (stripos($user, 'macintosh') !== FALSE) {
             return TRUE;
         } else if (stripos($user, 'windows') !== FALSE || stripos($user, 'linux') !== FALSE) {


### PR DESCRIPTION
HTTP_USER_AGENT is not always set, which causes an entry in the error log file, if WP_DEBUG is enabled.