### PR TITLE
Fix for lang CSS when using @media queries

### DIFF
--- a/langs/css/css.txt
+++ b/langs/css/css.txt
@@ -3,11 +3,11 @@
 #   ELEMENT_NAME [optional-css-class] REGULAR_EXPRESSION
 
     NAME                CSS
-    VERSION             1.9.0
+    VERSION             1.9.1
 
     COMMENT             (/\*.*?\*/)
     STRING              (?default)
-    NOTATION            \@[\w-]+[^;]*;?
+    NOTATION            \@[\w-]+[^;\{]*;?
 
     # For the <style> tag
     ATT_STR:STRING      (((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)'))


### PR DESCRIPTION
Media queries in CSS language were not highlighted correctly as the delimiter `{` was not recognized.

This commit fixes that bug.

Example:
```
@media print {
    /* do not print sidebars and comment forms */
    .sidebar {
        display: none;
    }
}
```