### PR TITLE
T-SQL strings aren't escaped by backslashes.

### DIFF
--- a/langs/tsql/tsql.txt
+++ b/langs/tsql/tsql.txt
@@ -6,7 +6,7 @@
     VERSION             1.8.0
 
     COMMENT             (/\*.*?\*/)|(--.*?$)
-    STRING              ((?<!\\)'.*?(?<!\\)')
+    STRING              ('[^']*')
     
     KEYWORD             \b(?alt:keyword.txt)\b
     TYPE                 \b(?alt:type.txt)\b


### PR DESCRIPTION
A second single quote escapes a quote in a string, which means the right thing just happens.

Before this change:
![image](https://cloud.githubusercontent.com/assets/809741/17251598/5f4e0744-55a1-11e6-9f1b-252fee798921.png)

After this change:
![image](https://cloud.githubusercontent.com/assets/809741/17251607/63b99a5a-55a1-11e6-91af-0575544c24c6.png)
