### PR TITLE
Fix strings being used as a numerical value

### DIFF
--- a/crayon_formatter.class.php
+++ b/crayon_formatter.class.php
@@ -115,8 +115,8 @@ class CrayonFormatter {
             $_line_height = $hl->setting_val(CrayonSettings::LINE_HEIGHT);
             // Don't allow line height to be less than font size
             $line_height = ($_line_height > $_font_size ? $_line_height : $_font_size) . 'px !important;';
-            $toolbar_height = $font_size * 1.5 . 'px !important;';
-            $info_height = $font_size * 1.4 . 'px !important;';
+            $toolbar_height = ($_font_size * 1.5) . 'px !important;';
+            $info_height = ($_font_size * 1.4) . 'px !important;';
 
             $font_style .= "font-size: $font_size line-height: $line_height";
             $toolbar_style .= "font-size: $font_size";
@@ -131,7 +131,7 @@ class CrayonFormatter {
         } else if (!$hl->is_inline()) {
             if (($font_size = CrayonGlobalSettings::get(CrayonSettings::FONT_SIZE)) !== FALSE) {
                 $font_size = $font_size->def() . 'px !important;';
-                $line_height = ($font_size * 1.4) . 'px !important;';
+                $line_height = ($font_size->def() * 1.4) . 'px !important;';
             }
         }
 


### PR DESCRIPTION
`$font_size` holds the font size as a string, e.g. (`"12px !important;"`), but is being used in calculations such as `$_font_size * 1.5`. On PHP 7+ this will give a notice. For calculations, the numerical value stored in `$_font_size`  or `CrayonGlobalSettings::get(CrayonSettings::FONT_SIZE))->def()` should be used instead.

Fixes one of the issues reported in https://wordpress.org/support/topic/failed-to-open-stream-error-when-creating-new-post/#post-8663430