### PR TITLE
alternate is not a data type

### DIFF
--- a/crayon_settings.class.php
+++ b/crayon_settings.class.php
@@ -397,7 +397,7 @@ class CrayonSettings {
      * This is used when saving form an HTML form to the db, and also when reading from the db
      * back into the global settings.
      * @param string $name
-     * @param alternate $value
+     * @param mixed $value
      */
     public static function validate($name, $value) {
         if (!is_string($name)) {


### PR DESCRIPTION
This commit changed all instances of `mixed` to `alternate`. Mixed is reserved word in PHP 7+ so most of those changes were valid. However reserved words relate only to function/class/constant names and not to doc-block tags. Here `@param mixed` has a particular meaning: that the parameter has no single data type. 

The error was probably a result of 'replace all'.