### PR TITLE
Bug fix: Removed string "px !important;" from $font_size which should have only number seeing its usage

### DIFF
--- a/crayon_formatter.class.php
+++ b/crayon_formatter.class.php
@@ -111,7 +111,7 @@ class CrayonFormatter {
         // TODO improve logic
         if ($hl->setting_val(CrayonSettings::FONT_SIZE_ENABLE)) {
             $_font_size = $hl->setting_val(CrayonSettings::FONT_SIZE);
-            $font_size = $_font_size . 'px !important;';
+            $font_size = $_font_size;
             $_line_height = $hl->setting_val(CrayonSettings::LINE_HEIGHT);
             // Don't allow line height to be less than font size
             $line_height = ($_line_height > $_font_size ? $_line_height : $_font_size) . 'px !important;';


### PR DESCRIPTION
removed ". 'px !important;'" because its value is used as number and it is yielding warning like

Notice: A non well formed numeric value encountered in /var/www/web/app/plugins/crayon-syntax-highlighter/crayon_formatter.class.php on line 118

Line 118: $toolbar_height = $font_size * 1.5 . 'px !important;'; 

So "$font_size" should not have the string 'px !important;' but it should have only number

And this string is added in different lines, so removing string from $font_size should be O.K.