### PR TITLE
Add filter for determince front-end script can load

### DIFF
--- a/crayon_wp.class.php
+++ b/crayon_wp.class.php
@@ -541,6 +541,16 @@ class CrayonWP {
     }
 
     public static function enqueue_resources() {
+	  
+	/**
+         * Script load or not
+         * @var bool
+         */
+        $can_load = apply_filters( 'crayon_scripts_load', true );
+        if( ! $can_load ) {
+            return;
+        }
+	    
         if (!self::$enqueued) {
 
             CrayonLog::debug('enqueue');


### PR DESCRIPTION
By this filter developers and users can determine front-end scripts where can load, this if for better performance in post or post type that not have any code.