### PR TITLE
Improvements to Clojure language

### DIFF
--- a/langs/clojure/clojure.txt
+++ b/langs/clojure/clojure.txt
@@ -13,7 +13,7 @@
     TYPE                \b(?alt:type.txt)\b
     HOF                 \b(?alt:hof.txt)\b
     VAR                 \b(?alt:vars.txt)\b
-    KEYWORD             (?<=\(|/)\s*[a-z-]*[a-z]\b
+    KEYWORD             (?<=\(|\/)\s*[a-zA-Z0-9->]{1,}[a-zA-Z0-9]\b
     
     IDENTIFIER          [a-z-]*[a-z]
     CONSTANT            :[a-zA-Z]+

--- a/langs/clojure/clojure.txt
+++ b/langs/clojure/clojure.txt
@@ -16,6 +16,6 @@
     KEYWORD             (?<=\()\s*[a-z-]*[a-z]\b
     
     IDENTIFIER          [a-z-]*[a-z]
-    CONSTANT            (?default)
+    CONSTANT            :[a-zA-Z]+
     OPERATOR            (?default)|\(|\)
     SYMBOL              (?default)

--- a/langs/clojure/clojure.txt
+++ b/langs/clojure/clojure.txt
@@ -13,7 +13,7 @@
     TYPE                \b(?alt:type.txt)\b
     HOF                 \b(?alt:hof.txt)\b
     VAR                 \b(?alt:vars.txt)\b
-    KEYWORD             (?<=\()\s*[a-z-]*[a-z]\b
+    KEYWORD             (?<=\(|/)\s*[a-z-]*[a-z]\b
     
     IDENTIFIER          [a-z-]*[a-z]
     CONSTANT            :[a-zA-Z]+

--- a/langs/clojure/clojure.txt
+++ b/langs/clojure/clojure.txt
@@ -16,6 +16,6 @@
     KEYWORD             (?<=\(|\/)\s*[a-zA-Z0-9->]{1,}[a-zA-Z0-9]\b
     
     IDENTIFIER          [a-z-]*[a-z]
-    CONSTANT            :[a-zA-Z]+
+    CONSTANT            :[a-zA-Z0-9]+
     OPERATOR            (?default)|\(|\)
     SYMBOL              (?default)


### PR DESCRIPTION
These are just a few matching improvements for Clojure language:

- using `CONSTANT` to highlight Clojure keywords: `:keyword`
- Better matching of `KEYWORDS`, as to say function calls: now it matches no matter the case, matches `namespace/function-call` completely and not only partially as previously and allows `from->to` naming highlighting