### PR TITLE
Fix compatibility with PHP 7.3

### DIFF
--- a/crayon_langs.class.php
+++ b/crayon_langs.class.php
@@ -337,7 +337,7 @@ class CrayonLang extends CrayonVersionResource {
 	// Override
 	function clean_id($id) {
         $id = CrayonUtil::space_to_hyphen( strtolower(trim($id)) );
-        return preg_replace('/[^\w-+#]/msi', '', $id);
+        return preg_replace('/[^\w\-+#]/msi', '', $id);
 	}
 
 	function ext($ext = NULL) {


### PR DESCRIPTION
The regex fails to parse in PHP 7.3, which broke the page in later functions.

```
PHP Warning:  preg_replace(): Compilation failed: invalid range in character class at offset 4 in /var/www/felixcat/wp-content/plugins/crayon-syntax-highlighter/crayon_langs.class.php on line 340
```