### PR TITLE
Update crayon_langs.class.php

### DIFF
--- a/crayon_langs.class.php
+++ b/crayon_langs.class.php
@@ -337,7 +337,7 @@ class CrayonLang extends CrayonVersionResource {
 	// Override
 	function clean_id($id) {
         $id = CrayonUtil::space_to_hyphen( strtolower(trim($id)) );
-        return preg_replace('/[^\w-+#]/msi', '', $id);
+        return preg_replace('/[^\w\-+#]/msi', '', $id);
 	}
 
 	function ext($ext = NULL) {


### PR DESCRIPTION
Line 340:
`[^\w-+#]` seems no longer a valid Regex ini PHP 7.3
`[^\w\-+#]` fixes this.