### PR TITLE
Move hyphen in regexp for better compatibility

### DIFF
--- a/crayon_langs.class.php
+++ b/crayon_langs.class.php
@@ -337,7 +337,7 @@ class CrayonLang extends CrayonVersionResource {
 	// Override
 	function clean_id($id) {
         $id = CrayonUtil::space_to_hyphen( strtolower(trim($id)) );
-        return preg_replace('/[^\w-+#]/msi', '', $id);
+        return preg_replace('/[^\w+#-]/msi', '', $id);
 	}
 
 	function ext($ext = NULL) {


### PR DESCRIPTION
In some versions of PHP (and/or PCRE) the hyphen has to be escaped or moved at the end of the regexp class to be considered as the literal '-' character. More info: https://stackoverflow.com/questions/24764212/preg-match-compilation-failed-invalid-range-in-character-class-at-offset#comment38430767_24767090
Tested on Wordpress 5.3 with PHP 7.4.