### PR TITLE
Fix "A non well formed numeric value encountered"

### DIFF
--- a/crayon_formatter.class.php
+++ b/crayon_formatter.class.php
@@ -115,8 +115,8 @@ class CrayonFormatter {
             $_line_height = $hl->setting_val(CrayonSettings::LINE_HEIGHT);
             // Don't allow line height to be less than font size
             $line_height = ($_line_height > $_font_size ? $_line_height : $_font_size) . 'px !important;';
-            $toolbar_height = $font_size * 1.5 . 'px !important;';
-            $info_height = $font_size * 1.4 . 'px !important;';
+            $toolbar_height = $_font_size * 1.5 . 'px !important;';
+            $info_height = $_font_size * 1.4 . 'px !important;';
 
             $font_style .= "font-size: $font_size line-height: $line_height";
             $toolbar_style .= "font-size: $font_size";


### PR DESCRIPTION
Fix for 
```
Notice: A non well formed numeric value encountered in crayon-syntax-highlighter/crayon_formatter.class.php
```